### PR TITLE
[Feature] Add conversation memory module

### DIFF
--- a/milo_core/__init__.py
+++ b/milo_core/__init__.py
@@ -1,0 +1,5 @@
+"""Core MILO package."""
+
+from .memory import Message, ConversationMemory
+
+__all__ = ["Message", "ConversationMemory"]

--- a/milo_core/memory.py
+++ b/milo_core/memory.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class Message:
+    """Represents a single conversational message."""
+
+    role: str
+    content: str
+
+
+class ConversationMemory:
+    """Simple in-memory store for recent conversation history.
+
+    This class keeps messages in memory for short-term context. Integration
+    with a Retrieval Augmented Generation (RAG) system can be added later by
+    extending ``add_message`` to also persist messages to a local knowledge
+    base and augment retrieval in ``get_messages``.
+    """
+
+    def __init__(self, max_messages: int = 20) -> None:
+        self.max_messages = max_messages
+        self._messages: List[Message] = []
+
+    def add_message(self, role: str, content: str) -> None:
+        """Add a new message to memory, trimming if necessary."""
+        self._messages.append(Message(role=role, content=content))
+        if len(self._messages) > self.max_messages:
+            # Keep only the most recent ``max_messages``
+            self._messages = self._messages[-self.max_messages :]
+
+        # Placeholder for future RAG integration.
+        # A hook here would store ``content`` in a local vector database
+        # for retrieval-augmented responses.
+
+    def get_messages(self, limit: int | None = None) -> List[Message]:
+        """Retrieve the most recent messages up to ``limit``."""
+        if limit is None or limit > len(self._messages):
+            return list(self._messages)
+        return self._messages[-limit:]

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,26 @@
+from milo_core.memory import ConversationMemory
+
+
+def test_add_and_retrieve_messages():
+    memory = ConversationMemory(max_messages=5)
+    memory.add_message("user", "Hello")
+    memory.add_message("assistant", "Hi")
+
+    messages = memory.get_messages()
+    assert len(messages) == 2
+    assert messages[0].role == "user"
+    assert messages[0].content == "Hello"
+    assert messages[1].role == "assistant"
+    assert messages[1].content == "Hi"
+
+
+def test_max_messages_limit():
+    memory = ConversationMemory(max_messages=2)
+    memory.add_message("user", "one")
+    memory.add_message("assistant", "two")
+    memory.add_message("user", "three")
+
+    messages = memory.get_messages()
+    assert len(messages) == 2
+    assert messages[0].content == "two"
+    assert messages[1].content == "three"


### PR DESCRIPTION
## Summary
- implement `ConversationMemory` and `Message` classes in `milo_core.memory`
- expose memory classes in package init
- add unit tests for the new memory module

## Testing
- `poetry run ruff format .`
- `poetry run ruff check .`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f89a996fc833081590edf22ea4f8c