### PR TITLE
[Docs] expand project overview and developer notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,42 @@
-# MILO-CodexDev
+# MILO - Minimal Input Life Organizer
+
+MILO aims to give users a private, local-first assistant. All core reasoning and data stay on the machine. New features are built as plugins so the core remains small and extensible.
+
+## Goals
+- **Local-first**: keep user data on device and run the AI locally.
+- **Plugin-based architecture**: skills live in the `plugins/` directory and are discovered by the `PluginManager`.
+
+## Development setup
+Install dependencies with Poetry:
+
+```bash
+poetry install
+```
+
+Add a new dependency using:
+
+```bash
+poetry add <package_name>
+```
+
+## Adding plugins
+Create a new file under `plugins/` with a class that subclasses `BaseSkill` and implements `execute`. When `PluginManager.discover_plugins()` runs, your skill will be loaded automatically.
+
+## Testing and formatting
+Run tests with:
+
+```bash
+poetry run pytest
+```
+
+Format the codebase using:
+
+```bash
+poetry run ruff format .
+```
+
+Check linting with:
+
+```bash
+poetry run ruff check .
+```


### PR DESCRIPTION
## Summary
- add project goals to the README
- document installing dependencies with Poetry and adding plugins
- include commands for tests, formatting, and linting

## Testing
- `poetry run ruff format .`
- `poetry run ruff check .`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f89a87dd083309f01b89b1980fd89