### PR TITLE
[Feature] Add short-term conversation memory

### DIFF
--- a/milo_core/memory.py
+++ b/milo_core/memory.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from typing import Deque, List
+
+
+@dataclass
+class Message:
+    """Represents a single chat message."""
+
+    role: str
+    content: str
+
+
+class ShortTermMemory:
+    """In-memory store for recent conversation messages.
+
+    Parameters
+    ----------
+    max_messages:
+        Maximum number of messages to retain. When the limit is
+        reached, older messages are discarded.
+    """
+
+    def __init__(self, max_messages: int = 50) -> None:
+        self.max_messages = max_messages
+        self._messages: Deque[Message] = deque(maxlen=max_messages)
+
+    def add_message(self, role: str, content: str) -> None:
+        """Add a message to memory."""
+        self._messages.append(Message(role=role, content=content))
+
+    def get_messages(self) -> List[Message]:
+        """Return a list of stored messages in chronological order."""
+        return list(self._messages)
+
+    def clear(self) -> None:
+        """Remove all messages from memory."""
+        self._messages.clear()
+
+    # NOTE: Retrieval augmented generation (RAG) integration would hook into
+    # this class. For example, `get_messages` could be expanded to merge
+    # results from a local vector store containing long-term knowledge.

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from milo_core.memory import Message, ShortTermMemory
+
+
+def test_add_and_retrieve_messages() -> None:
+    memory = ShortTermMemory(max_messages=3)
+    memory.add_message("user", "hello")
+    memory.add_message("assistant", "hi")
+    assert memory.get_messages() == [
+        Message(role="user", content="hello"),
+        Message(role="assistant", content="hi"),
+    ]
+
+
+def test_memory_discards_old_messages_when_full() -> None:
+    memory = ShortTermMemory(max_messages=2)
+    memory.add_message("user", "one")
+    memory.add_message("assistant", "two")
+    memory.add_message("user", "three")
+    messages = memory.get_messages()
+    assert len(messages) == 2
+    assert messages[0].content == "two"
+    assert messages[1].content == "three"
+
+
+def test_clear_memory() -> None:
+    memory = ShortTermMemory()
+    memory.add_message("user", "foo")
+    memory.clear()
+    assert memory.get_messages() == []


### PR DESCRIPTION
## Summary
- implement `ShortTermMemory` and `Message` classes for storing recent conversation messages
- add unit tests covering memory storage behaviour

## Testing
- `poetry run ruff format .`
- `poetry run ruff check .`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f8c72643c8330ad8cc18e6244c048