### PR TITLE
[Feature] Add voice assistant entrypoint

### DIFF
--- a/milo_core/__main__.py
+++ b/milo_core/__main__.py
@@ -1,0 +1,4 @@
+from .main import main
+
+if __name__ == "__main__":
+    main()

--- a/milo_core/main.py
+++ b/milo_core/main.py
@@ -1,0 +1,47 @@
+import argparse
+from typing import List
+
+from milo_core.llm.gemma import GemmaLocalModel
+from milo_core.plugin_manager import PluginManager
+from milo_core.voice.conversation import converse
+from milo_core.voice.engines import PocketsphinxSTT, Pyttsx3TTS
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Create and return the CLI argument parser."""
+    parser = argparse.ArgumentParser(description="Run the MILO voice assistant")
+    parser.add_argument(
+        "--model-dir",
+        default="models/gemma-3-4b-it",
+        help="Path to the local model directory",
+    )
+    return parser
+
+
+def run(args: argparse.Namespace) -> None:
+    """Initialize components and start the conversation loop."""
+    model = GemmaLocalModel(args.model_dir)
+    model.load_model()
+
+    stt = PocketsphinxSTT()
+    tts = Pyttsx3TTS()
+
+    pm = PluginManager()
+    pm.discover_plugins()
+
+    try:
+        converse(model, stt, tts)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        model.unload()
+
+
+def main(argv: List[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    run(args)
+
+
+if __name__ == "__main__":  # pragma: no cover - entry point
+    main()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from milo_core.main import main
+
+
+@patch("milo_core.main.converse")
+@patch("milo_core.main.GemmaLocalModel")
+@patch("milo_core.main.PocketsphinxSTT")
+@patch("milo_core.main.Pyttsx3TTS")
+@patch("milo_core.main.PluginManager")
+def test_main_starts_conversation(
+    mock_pm,
+    mock_tts,
+    mock_stt,
+    mock_model,
+    mock_converse,
+) -> None:
+    main([])
+    mock_model.assert_called_with("models/gemma-3-4b-it")
+    mock_model.return_value.load_model.assert_called_once()
+    mock_pm.return_value.discover_plugins.assert_called_once()
+    mock_converse.assert_called_once()


### PR DESCRIPTION
## Summary
- add `main.py` to start the MILO voice assistant
- add `__main__.py` to allow `python -m milo_core`
- test that main entrypoint initialises components

## Testing
- `poetry run ruff format .`
- `poetry run ruff check .`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f9364abe08330a30dce8d7948896e