### PR TITLE
[Deps] Include PyAudio via speechrecognition extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,9 @@ Check linting with:
 ```bash
 poetry run ruff check .
 ```
+
+## Audio requirements
+Speech recognition depends on PyAudio, which requires OS-level
+`portaudio` libraries. The Python package is installed automatically
+through Poetry or the generated `requirements.txt`, but ensure your
+system has the necessary build tools and `portaudio` headers.

--- a/poetry.lock
+++ b/poetry.lock
@@ -791,6 +791,32 @@ dev = ["pre-commit", "tox"]
 testing = ["coverage", "pytest", "pytest-benchmark"]
 
 [[package]]
+name = "pyaudio"
+version = "0.2.14"
+description = "Cross-platform audio I/O with PortAudio"
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "PyAudio-0.2.14-cp310-cp310-win32.whl", hash = "sha256:126065b5e82a1c03ba16e7c0404d8f54e17368836e7d2d92427358ad44fefe61"},
+    {file = "PyAudio-0.2.14-cp310-cp310-win_amd64.whl", hash = "sha256:2a166fc88d435a2779810dd2678354adc33499e9d4d7f937f28b20cc55893e83"},
+    {file = "PyAudio-0.2.14-cp311-cp311-win32.whl", hash = "sha256:506b32a595f8693811682ab4b127602d404df7dfc453b499c91a80d0f7bad289"},
+    {file = "PyAudio-0.2.14-cp311-cp311-win_amd64.whl", hash = "sha256:bbeb01d36a2f472ae5ee5e1451cacc42112986abe622f735bb870a5db77cf903"},
+    {file = "PyAudio-0.2.14-cp312-cp312-win32.whl", hash = "sha256:5fce4bcdd2e0e8c063d835dbe2860dac46437506af509353c7f8114d4bacbd5b"},
+    {file = "PyAudio-0.2.14-cp312-cp312-win_amd64.whl", hash = "sha256:12f2f1ba04e06ff95d80700a78967897a489c05e093e3bffa05a84ed9c0a7fa3"},
+    {file = "PyAudio-0.2.14-cp313-cp313-win32.whl", hash = "sha256:95328285b4dab57ea8c52a4a996cb52be6d629353315be5bfda403d15932a497"},
+    {file = "PyAudio-0.2.14-cp313-cp313-win_amd64.whl", hash = "sha256:692d8c1446f52ed2662120bcd9ddcb5aa2b71f38bda31e58b19fb4672fffba69"},
+    {file = "PyAudio-0.2.14-cp38-cp38-win32.whl", hash = "sha256:858caf35b05c26d8fc62f1efa2e8f53d5fa1a01164842bd622f70ddc41f55000"},
+    {file = "PyAudio-0.2.14-cp38-cp38-win_amd64.whl", hash = "sha256:2dac0d6d675fe7e181ba88f2de88d321059b69abd52e3f4934a8878e03a7a074"},
+    {file = "PyAudio-0.2.14-cp39-cp39-win32.whl", hash = "sha256:f745109634a7c19fa4d6b8b7d6967c3123d988c9ade0cd35d4295ee1acdb53e9"},
+    {file = "PyAudio-0.2.14-cp39-cp39-win_amd64.whl", hash = "sha256:009f357ee5aa6bc8eb19d69921cd30e98c42cddd34210615d592a71d09c4bd57"},
+    {file = "PyAudio-0.2.14.tar.gz", hash = "sha256:78dfff3879b4994d1f4fc6485646a57755c6ee3c19647a491f790a0895bd2f87"},
+]
+
+[package.extras]
+test = ["numpy"]
+
+[[package]]
 name = "pygments"
 version = "2.19.1"
 description = "Pygments is a syntax highlighting package written in Python."
@@ -4599,6 +4625,7 @@ files = [
 
 [package.dependencies]
 audioop-lts = {version = "*", markers = "python_version >= \"3.13\""}
+PyAudio = {version = ">=0.2.11", optional = true, markers = "extra == \"audio\""}
 standard-aifc = {version = "*", markers = "python_version >= \"3.13\""}
 typing-extensions = "*"
 
@@ -4952,4 +4979,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10"
-content-hash = "fb429906a72f73e1d8d2ca33822abdd9d57bf27640a98668906e52635ab5a772"
+content-hash = "842f7943a29a35abd42694b5eecb178873bdb250c740ce1f6c9e89c5a5bd8918"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "transformers (>=4.52.4,<5.0.0)",
     "torch (>=2.7.0,<3.0.0)",
     "pyttsx3 (>=2.98,<3.0)",
-    "speechrecognition (>=3.14.3,<4.0.0)"
+    "speechrecognition[audio] (>=3.14.3,<4.0.0)"
 ]
 
 # This section is for Poetry's specific configuration

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,7 @@ nvidia-nccl-cu12==2.26.2 ; platform_system == "Linux" and platform_machine == "x
 nvidia-nvjitlink-cu12==12.6.85 ; platform_system == "Linux" and platform_machine == "x86_64" and python_version >= "3.10"
 nvidia-nvtx-cu12==12.6.77 ; platform_system == "Linux" and platform_machine == "x86_64" and python_version >= "3.10"
 packaging==25.0 ; python_version >= "3.10"
+pyaudio==0.2.14 ; python_version >= "3.10"
 pyobjc-core==11.0 ; python_version >= "3.10" and platform_system == "Darwin"
 pyobjc-framework-accessibility==11.0 ; platform_system == "Darwin" and platform_release >= "20.0" and python_version >= "3.10"
 pyobjc-framework-accounts==11.0 ; platform_system == "Darwin" and platform_release >= "12.0" and python_version >= "3.10"


### PR DESCRIPTION
## Summary
- depend on `speechrecognition[audio]` so PyAudio is installed
- refresh `poetry.lock` and export new `requirements.txt`
- document the need for OS level portaudio

## Testing
- `poetry run ruff format .`
- `poetry run ruff check .`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_683f97a7de848330942f1df0d864c5c7