### PR TITLE
[Fix] Mirror dependencies for poetry

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4979,4 +4979,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10"
-content-hash = "842f7943a29a35abd42694b5eecb178873bdb250c740ce1f6c9e89c5a5bd8918"
+content-hash = "33e93ca7fe9436d051ab7d0073892a29554cdb5b5145e882b1174acbcf91e1be"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,11 @@ packages = [{include = "milo_core"}] # This tells Poetry your package code is in
 [tool.poetry.dependencies]
 python = ">=3.10" # Should match [project].requires-python
 # Main dependencies will also be reflected here by 'poetry add'
+requests = ">=2.32.3,<3.0.0"
+transformers = ">=4.52.4,<5.0.0"
+torch = ">=2.7.0,<3.0.0"
+pyttsx3 = ">=2.98,<3.0"
+"speechrecognition[audio]" = ">=3.14.3,<4.0.0"
 
 [tool.poetry.group.dev.dependencies]
 # Development dependencies like ruff and pytest will be added here by


### PR DESCRIPTION
## Summary
- add runtime dependencies to `[tool.poetry.dependencies]`
- update `poetry.lock`

## Testing
- `poetry run pytest`
- `poetry run ruff check .`
- `poetry run ruff format --check .`


------
https://chatgpt.com/codex/tasks/task_e_683fc67380d083308a0eb957ead6ddbf