### PR TITLE
[Feature] Add CLI entrypoint and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ brew install portaudio
 Start the assistant with:
 
 ```bash
-poetry run python -m milo_core
+poetry run milo-core
 ```
 
 Stop it at any time with `Ctrl+C`. New plugins added to the `plugins/`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ dependencies = [
     "speechrecognition[audio] (>=3.14.3,<4.0.0)"
 ]
 
+[project.scripts]
+milo-core = "milo_core.main:main"
+
 # This section is for Poetry's specific configuration
 [tool.poetry]
 name = "milo-codexdev" # Should match [project].name

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_module_entrypoint(tmp_path: Path) -> None:
+    stubs = tmp_path / "stubs"
+    stubs.mkdir()
+
+    (stubs / "torch.py").write_text("float16 = None")
+    (stubs / "pyttsx3.py").write_text("")
+    (stubs / "speech_recognition.py").write_text(
+        "Recognizer=None\nMicrophone=None\nUnknownValueError=Exception"
+    )
+    transformers = stubs / "transformers"
+    transformers.mkdir()
+    transformers.joinpath("__init__.py").write_text(
+        """
+class AutoModelForCausalLM:
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        return cls()
+
+    def generate(self, *args, **kwargs):
+        return [[0]]
+
+
+class AutoTokenizer:
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        return cls()
+
+    def __call__(self, *args, **kwargs):
+        return type('Obj', (), {'input_ids': [[0]]})
+
+    def decode(self, *args, **kwargs):
+        return ''
+
+
+class TextIteratorStreamer:
+    def __iter__(self):
+        return iter([])
+"""
+    )
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = f"{stubs}{os.pathsep}{Path.cwd()}"
+
+    result = subprocess.run(
+        [sys.executable, "-m", "milo_core", "--help"],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "Run the MILO voice assistant" in result.stdout


### PR DESCRIPTION
## Summary
- expose a `milo-core` script in `pyproject.toml`
- document running MILO using `poetry run milo-core`
- add a test ensuring `python -m milo_core` runs

## Testing
- `poetry run ruff format .`
- `poetry run ruff check .`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683fd67fffa08330a854f4cd68e068e9