### PR TITLE
[Feature] Add command execution and tests

### DIFF
--- a/milo_core/__init__.py
+++ b/milo_core/__init__.py
@@ -1,3 +1,4 @@
 from .workflows import trigger_workflow as trigger_workflow
+from .commands import execute_command as execute_command, CommandError as CommandError
 
-__all__ = ["trigger_workflow"]
+__all__ = ["trigger_workflow", "execute_command", "CommandError"]

--- a/milo_core/commands.py
+++ b/milo_core/commands.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+from .plugin_manager import PluginManager
+from .workflows import trigger_workflow
+
+
+class CommandError(Exception):
+    """Raised when a command cannot be parsed or executed."""
+
+
+def execute_command(
+    command: str | Dict[str, Any], plugin_manager: PluginManager
+) -> Any:
+    """Parse and execute a skill or workflow command.
+
+    Parameters
+    ----------
+    command:
+        JSON string or dictionary describing the action to perform. Expected
+        keys:
+        ``type`` (``"skill"`` or ``"workflow"``), along with ``name`` for skills
+        or ``id`` for workflows. ``args`` and ``kwargs`` are optional for skills,
+        ``payload`` is optional for workflows.
+    plugin_manager:
+        Manager used to look up loaded skills.
+
+    Returns
+    -------
+    Any
+        The result of ``skill.execute`` or the ``requests.Response`` from
+        ``trigger_workflow``.
+    """
+
+    if isinstance(command, str):
+        try:
+            data: Dict[str, Any] = json.loads(command)
+        except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+            raise CommandError("Invalid command JSON") from exc
+    else:
+        data = command
+
+    cmd_type = data.get("type")
+    if cmd_type == "skill":
+        skill_name = data.get("name")
+        if not skill_name:
+            raise CommandError("Missing skill name")
+        skill = plugin_manager.get_skill_by_name(str(skill_name))
+        if skill is None:
+            raise CommandError(f"Unknown skill: {skill_name}")
+        args = data.get("args", [])
+        kwargs = data.get("kwargs", {})
+        return skill.execute(*args, **kwargs)
+
+    if cmd_type == "workflow":
+        workflow_id = data.get("id")
+        if not workflow_id:
+            raise CommandError("Missing workflow id")
+        payload = data.get("payload")
+        response = trigger_workflow(str(workflow_id), payload)
+        if not getattr(response, "ok", False):
+            raise CommandError(
+                f"Workflow {workflow_id} failed with status {getattr(response, 'status_code', 'unknown')}"
+            )
+        return response
+
+    raise CommandError("Unsupported command type")

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from milo_core.commands import execute_command, CommandError
+from milo_core.plugin_manager import PluginManager
+from plugins.test_skill import TestSkill
+
+
+def setup_manager() -> PluginManager:
+    pm = PluginManager()
+    # manually register the test skill instead of discovery to avoid filesystem dependency
+    pm.skills = [TestSkill()]
+    return pm
+
+
+def test_execute_skill_success() -> None:
+    pm = setup_manager()
+    result = execute_command({"type": "skill", "name": "test"}, pm)
+    assert result == "executed"
+
+
+def test_execute_skill_unknown() -> None:
+    pm = setup_manager()
+    try:
+        execute_command({"type": "skill", "name": "unknown"}, pm)
+    except CommandError as exc:
+        assert "Unknown skill" in str(exc)
+    else:  # pragma: no cover - ensure failure if not raised
+        raise AssertionError("Expected CommandError")
+
+
+@patch("milo_core.commands.trigger_workflow")
+def test_execute_workflow_success(mock_trigger) -> None:
+    mock_resp = MagicMock()
+    mock_resp.ok = True
+    mock_trigger.return_value = mock_resp
+    pm = setup_manager()
+    result = execute_command({"type": "workflow", "id": "wf"}, pm)
+    assert result is mock_resp
+    mock_trigger.assert_called_once_with("wf", None)
+
+
+@patch("milo_core.commands.trigger_workflow")
+def test_execute_workflow_failure(mock_trigger) -> None:
+    mock_resp = MagicMock()
+    mock_resp.ok = False
+    mock_resp.status_code = 500
+    mock_trigger.return_value = mock_resp
+    pm = setup_manager()
+    try:
+        execute_command({"type": "workflow", "id": "wf"}, pm)
+    except CommandError as exc:
+        assert "failed" in str(exc)
+    else:
+        raise AssertionError("Expected CommandError")


### PR DESCRIPTION
## Summary
- add `milo_core.commands` with `execute_command` helper
- expose `execute_command` and `CommandError`
- test skill & workflow execution including errors

## Testing
- `poetry run ruff format .`
- `poetry run ruff check .`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68421005ac4c8330bc2f7da635f00be8