### PR TITLE
[Feature] Ignore test plugins by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This script requires `huggingface-cli` and stores the model in
 directory.
 
 ## Adding plugins
-Create a new file under `plugins/` with a class that subclasses `BaseSkill` and implements `execute`. When `PluginManager.discover_plugins()` runs, your skill will be loaded automatically.
+Create a new file under `plugins/` with a class that subclasses `BaseSkill` and implements `execute`. When `PluginManager.discover_plugins()` runs, your skill will be loaded automatically. Files named `test_*.py` are skipped by default; set the `MILO_INCLUDE_TEST_PLUGINS=1` environment variable or pass `include_tests=True` to `discover_plugins()` to load them.
 
 ## Testing and formatting
 Run tests with:

--- a/milo_core/plugin_manager.py
+++ b/milo_core/plugin_manager.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib
 import inspect
+import os
 import pkgutil
 from pathlib import Path
 from types import ModuleType
@@ -19,12 +20,23 @@ class PluginManager:
         )
         self.skills: List[BaseSkill] = []
 
-    def discover_plugins(self) -> None:
-        """Find and import skill plugins under ``plugins_path``."""
+    def discover_plugins(self, include_tests: bool | None = None) -> None:
+        """Find and import skill plugins under ``plugins_path``.
+
+        By default, modules with filenames starting with ``test_`` are skipped.
+        Set ``include_tests=True`` or the ``MILO_INCLUDE_TEST_PLUGINS``
+        environment variable to load them.
+        """
         if not self.plugins_path.exists():
             return
 
+        if include_tests is None:
+            include_tests_env = os.getenv("MILO_INCLUDE_TEST_PLUGINS", "").lower()
+            include_tests = include_tests_env in {"1", "true", "yes"}
+
         for module_info in pkgutil.iter_modules([str(self.plugins_path)]):
+            if module_info.name.startswith("test_") and not include_tests:
+                continue
             module = importlib.import_module(f"plugins.{module_info.name}")
             self._load_from_module(module)
 

--- a/tests/test_plugin_manager.py
+++ b/tests/test_plugin_manager.py
@@ -4,11 +4,17 @@ from milo_core.plugin_manager import PluginManager
 from plugins.base import BaseSkill
 
 
-def test_discover_plugins():
+def test_discover_plugins_ignores_test_plugins_by_default() -> None:
+    manager = PluginManager()
+    manager.discover_plugins()
+    assert manager.get_skill_by_name("test") is None
+
+
+def test_discover_plugins_can_include_tests(monkeypatch) -> None:
+    monkeypatch.setenv("MILO_INCLUDE_TEST_PLUGINS", "1")
     manager = PluginManager()
     manager.discover_plugins()
     skill = manager.get_skill_by_name("test")
-    assert skill is not None
     assert isinstance(skill, BaseSkill)
     assert skill.execute() == "executed"
 


### PR DESCRIPTION
## Summary
- update PluginManager to skip `test_*.py` modules unless enabled
- document optional loading of test plugins in README
- add tests covering default behaviour and opt-in via env var

## Testing
- `poetry run ruff format .`
- `poetry run ruff check .`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842100c6810833096e0730408b42528