### PR TITLE
[Refactor] Update default voice engines

### DIFF
--- a/milo_core/main.py
+++ b/milo_core/main.py
@@ -4,7 +4,7 @@ from typing import List
 from milo_core.llm.gemma import GemmaLocalModel
 from milo_core.plugin_manager import PluginManager
 from milo_core.voice.conversation import converse
-from milo_core.voice.engines import PocketsphinxSTT, Pyttsx3TTS
+from milo_core.voice.engines import WhisperSTT, CoquiTTS
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -23,8 +23,8 @@ def run(args: argparse.Namespace) -> None:
     model = GemmaLocalModel(args.model_dir)
     model.load_model()
 
-    stt = PocketsphinxSTT()
-    tts = Pyttsx3TTS()
+    stt = WhisperSTT()
+    tts = CoquiTTS()
 
     pm = PluginManager()
     pm.discover_plugins()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,8 +7,8 @@ from milo_core.main import main
 
 @patch("milo_core.main.converse")
 @patch("milo_core.main.GemmaLocalModel")
-@patch("milo_core.main.PocketsphinxSTT")
-@patch("milo_core.main.Pyttsx3TTS")
+@patch("milo_core.main.WhisperSTT")
+@patch("milo_core.main.CoquiTTS")
 @patch("milo_core.main.PluginManager")
 def test_main_starts_conversation(
     mock_pm,


### PR DESCRIPTION
## Summary
- swap `PocketsphinxSTT`/`Pyttsx3TTS` for `WhisperSTT`/`CoquiTTS` in `milo_core.main`
- adjust tests for new imports

## Testing
- `poetry run ruff format .`
- `poetry run ruff check .`
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_684219b40da483308a0356c6ad9fd8ac