### PR TITLE
[Fix] update tests for new voice engines

### DIFF
--- a/milo_core/main.py
+++ b/milo_core/main.py
@@ -4,7 +4,7 @@ from typing import List
 from milo_core.llm.gemma import GemmaLocalModel
 from milo_core.plugin_manager import PluginManager
 from milo_core.voice.conversation import converse
-from milo_core.voice.engines import PocketsphinxSTT, Pyttsx3TTS
+from milo_core.voice.engines import CoquiTTS, WhisperSTT
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -23,8 +23,8 @@ def run(args: argparse.Namespace) -> None:
     model = GemmaLocalModel(args.model_dir)
     model.load_model()
 
-    stt = PocketsphinxSTT()
-    tts = Pyttsx3TTS()
+    stt = WhisperSTT()
+    tts = CoquiTTS()
 
     pm = PluginManager()
     pm.discover_plugins()

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -11,9 +11,16 @@ def test_module_entrypoint(tmp_path: Path) -> None:
     stubs.mkdir()
 
     (stubs / "torch.py").write_text("float16 = None")
-    (stubs / "pyttsx3.py").write_text("")
-    (stubs / "speech_recognition.py").write_text(
-        "Recognizer=None\nMicrophone=None\nUnknownValueError=Exception"
+    (stubs / "whisper.py").write_text(
+        "def load_model(name):\n    class M:\n        def transcribe(self, audio, fp16=False):\n            return {'text': ''}\n    return M()"
+    )
+    tts_pkg = stubs / "TTS"
+    tts_pkg.mkdir()
+    (tts_pkg / "__init__.py").write_text("")
+    api_pkg = tts_pkg / "api"
+    api_pkg.mkdir()
+    api_pkg.joinpath("__init__.py").write_text(
+        "class TTS:\n    def __init__(self, *a, **k):\n        pass\n    def tts(self, text):\n        return []\n    class synthesizer:\n        output_sample_rate = 16000"
     )
     transformers = stubs / "transformers"
     transformers.mkdir()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,8 +7,8 @@ from milo_core.main import main
 
 @patch("milo_core.main.converse")
 @patch("milo_core.main.GemmaLocalModel")
-@patch("milo_core.main.PocketsphinxSTT")
-@patch("milo_core.main.Pyttsx3TTS")
+@patch("milo_core.main.WhisperSTT")
+@patch("milo_core.main.CoquiTTS")
 @patch("milo_core.main.PluginManager")
 def test_main_starts_conversation(
     mock_pm,


### PR DESCRIPTION
## Summary
- update tests to patch `WhisperSTT` and `CoquiTTS`
- update entrypoint stubs for new voice dependencies
- switch main runtime to use the new voice engines

## Testing
- `poetry run ruff check .`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684219b8ae2c833099b7a897e5baa828