### PR TITLE
[Fix] stub whisper and TTS modules in entrypoint test

### DIFF
--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -42,6 +42,19 @@ class TextIteratorStreamer:
 """
     )
 
+    # stub whisper and TTS modules so imports succeed
+    (stubs / "whisper.py").write_text(
+        "def load_model(*args, **kwargs):\n    return None\n"
+    )
+    tts_pkg = stubs / "TTS"
+    tts_pkg.mkdir()
+    tts_pkg.joinpath("__init__.py").write_text("")
+    api_pkg = tts_pkg / "api"
+    api_pkg.mkdir()
+    api_pkg.joinpath("__init__.py").write_text(
+        "class TTS:\n    def __init__(self, *a, **k):\n        pass\n"
+    )
+
     env = os.environ.copy()
     env["PYTHONPATH"] = f"{stubs}{os.pathsep}{Path.cwd()}"
 


### PR DESCRIPTION
## Summary
- add stubs for `whisper` and `TTS` modules in `tests/test_entrypoint.py`
- keep existing patches for new voice engines in `tests/test_main.py`

## Testing
- `poetry run ruff format tests/test_entrypoint.py tests/test_main.py`
- `poetry run ruff check tests/test_entrypoint.py tests/test_main.py`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68421ccb69c0833085ec0c84e0f4abcb