### PR TITLE
[Refactor] switch audio IO to ffmpeg

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ poetry run ruff check .
 
 ## Audio requirements
 Speech recognition is powered by Whisper via the `openai-whisper` package.
-Text-to-speech uses Coqui TTS from the `TTS` package. Both components rely
-on the `sounddevice` library for microphone input and speaker output.
-Ensure `ffmpeg` is installed so audio can be decoded and played back.
+Text-to-speech uses Coqui TTS from the `TTS` package. Audio capture and
+playback are handled by `ffmpeg` and `ffplay`, so make sure these tools are
+installed and available on your `PATH`.
 
 Linux example:
 

--- a/milo_core/voice/engines.py
+++ b/milo_core/voice/engines.py
@@ -2,38 +2,65 @@ from __future__ import annotations
 
 import queue
 import threading
+import subprocess
 from typing import Iterable
 
 import numpy as np
-import sounddevice as sd
 
 from .interface import SpeechToText, TextToSpeech
 
 
 class WhisperSTT(SpeechToText):
-    """Speech recognition using ``whisper`` with ``sounddevice`` input."""
+    """Speech recognition using ``whisper`` with ``ffmpeg`` input."""
 
     def __init__(
-        self, model: str = "base", sample_rate: int = 16_000, block_size: int = 16_000
+        self,
+        model: str = "base",
+        sample_rate: int = 16_000,
+        block_size: int = 16_000,
+        input_format: str = "pulse",
+        input_device: str = "default",
     ) -> None:
         from whisper import load_model  # lazy import
 
         self.model = load_model(model)
         self.sample_rate = sample_rate
         self.block_size = block_size
+        self.input_format = input_format
+        self.input_device = input_device
 
     def listen(self) -> str:
-        audio = sd.rec(
-            self.block_size, samplerate=self.sample_rate, channels=1, dtype="float32"
+        duration = self.block_size / self.sample_rate
+        proc = subprocess.run(
+            [
+                "ffmpeg",
+                "-nostdin",
+                "-loglevel",
+                "quiet",
+                "-f",
+                self.input_format,
+                "-i",
+                self.input_device,
+                "-t",
+                str(duration),
+                "-ar",
+                str(self.sample_rate),
+                "-ac",
+                "1",
+                "-f",
+                "f32le",
+                "-",
+            ],
+            stdout=subprocess.PIPE,
+            check=False,
         )
-        sd.wait()
-        samples = np.squeeze(audio)
+        samples = np.frombuffer(proc.stdout, dtype=np.float32)
         result = self.model.transcribe(samples, fp16=False)
         return result.get("text", "")
 
 
 class CoquiTTS(TextToSpeech):
-    """Text to speech engine using ``Coqui TTS`` and ``sounddevice`` playback."""
+    """Text to speech engine using ``Coqui TTS`` and ``ffplay`` playback."""
 
     def __init__(
         self, model_name: str = "tts_models/en/ljspeech/tacotron2-DDC"
@@ -46,6 +73,7 @@ class CoquiTTS(TextToSpeech):
         self.tts = Coqui(model_name)
         self._queue: queue.Queue[str] = queue.Queue()
         self._stop_event = threading.Event()
+        self._process: subprocess.Popen | None = None
         self._thread = threading.Thread(target=self._run, daemon=True)
         self._thread.start()
 
@@ -56,8 +84,27 @@ class CoquiTTS(TextToSpeech):
                 break
             if not self._stop_event.is_set():
                 audio = self.tts.tts(text)
-                sd.play(audio, samplerate=self.tts.synthesizer.output_sample_rate)
-                sd.wait()
+                self._process = subprocess.Popen(
+                    [
+                        "ffplay",
+                        "-autoexit",
+                        "-nodisp",
+                        "-loglevel",
+                        "quiet",
+                        "-f",
+                        "f32le",
+                        "-ar",
+                        str(self.tts.synthesizer.output_sample_rate),
+                        "-ac",
+                        "1",
+                        "-",
+                    ],
+                    stdin=subprocess.PIPE,
+                )
+                assert self._process.stdin is not None
+                self._process.stdin.write(audio.astype(np.float32).tobytes())
+                self._process.stdin.close()
+                self._process.wait()
             self._queue.task_done()
             self._stop_event.clear()
 
@@ -69,4 +116,6 @@ class CoquiTTS(TextToSpeech):
 
     def stop(self) -> None:
         self._stop_event.set()
-        sd.stop()
+        if self._process and self._process.poll() is None:
+            self._process.terminate()
+            self._process = None

--- a/poetry.lock
+++ b/poetry.lock
@@ -369,6 +369,7 @@ description = "Foreign Function Interface for Python calling C code."
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "python_version < \"3.12\""
 files = [
     {file = "cffi-1.17.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:df8b1c11f177bc2313ec4b2d46baec87a5f3e71fc8b45dab2ee7cae86d9aba14"},
     {file = "cffi-1.17.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8f2cdc858323644ab277e9bb925ad72ae0e67f69e804f4898c070998d50b1a67"},
@@ -3440,6 +3441,7 @@ description = "C parser in Python"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
+markers = "python_version < \"3.12\""
 files = [
     {file = "pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc"},
     {file = "pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6"},
@@ -4289,27 +4291,6 @@ ssh = ["paramiko"]
 test = ["awscli", "azure-common", "azure-core", "azure-storage-blob", "boto3", "google-cloud-storage (>=2.6.0)", "moto[server]", "numpy", "paramiko", "pyopenssl", "pytest", "pytest-benchmark", "pytest-rerunfailures", "requests", "responses", "zstandard"]
 webhdfs = ["requests"]
 zst = ["zstandard"]
-
-[[package]]
-name = "sounddevice"
-version = "0.5.2"
-description = "Play and Record Sound with Python"
-optional = false
-python-versions = ">=3.7"
-groups = ["main"]
-files = [
-    {file = "sounddevice-0.5.2-py3-none-any.whl", hash = "sha256:82375859fac2e73295a4ab3fc60bd4782743157adc339561c1f1142af472f505"},
-    {file = "sounddevice-0.5.2-py3-none-macosx_10_6_x86_64.macosx_10_6_universal2.whl", hash = "sha256:943f27e66037d41435bdd0293454072cdf657b594c9cde63cd01ee3daaac7ab3"},
-    {file = "sounddevice-0.5.2-py3-none-win32.whl", hash = "sha256:3a113ce614a2c557f14737cb20123ae6298c91fc9301eb014ada0cba6d248c5f"},
-    {file = "sounddevice-0.5.2-py3-none-win_amd64.whl", hash = "sha256:e18944b767d2dac3771a7771bdd7ff7d3acd7d334e72c4bedab17d1aed5dbc22"},
-    {file = "sounddevice-0.5.2.tar.gz", hash = "sha256:c634d51bd4e922d6f0fa5e1a975cc897c947f61d31da9f79ba7ea34dff448b49"},
-]
-
-[package.dependencies]
-CFFI = ">=1.0"
-
-[package.extras]
-numpy = ["NumPy"]
 
 [[package]]
 name = "soundfile"
@@ -5594,4 +5575,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10"
-content-hash = "af251dca9dc1ef2ec48955cc18b61607d4ba79b709508f8da3c2d3eddbe7c633"
+content-hash = "2f585ef0bcbac238f2e63bf72accb98f80208b3506d1ab4331abb87f84b45255"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ dependencies = [
     "requests (>=2.32.3,<3.0.0)",
     "transformers (>=4.52.4,<5.0.0)",
     "torch (>=2.7.0,<3.0.0)",
-    "sounddevice (>=0.5.2,<0.6.0)",
     "openai-whisper (>=20240930,<20240931)",
     "TTS (>=0.22.0,<1.0.0); python_version < '3.12'"
 ]
@@ -34,7 +33,6 @@ python = ">=3.10" # Should match [project].requires-python
 requests = ">=2.32.3,<3.0.0"
 transformers = ">=4.52.4,<5.0.0"
 torch = ">=2.7.0,<3.0.0"
-sounddevice = ">=0.5.2,<0.6.0"
 "openai-whisper" = ">=20240930,<20240931"
 TTS = {version = ">=0.22.0,<1.0.0", markers = "python_version < '3.12'"}
 

--- a/tests/test_voice_engines.py
+++ b/tests/test_voice_engines.py
@@ -13,16 +13,12 @@ def test_whisper_stt_listen() -> None:
     mock_model = MagicMock()
     mock_model.transcribe.return_value = {"text": "hello"}
     with patch("whisper.load_model", return_value=mock_model):
-        with (
-            patch("milo_core.voice.engines.sd.rec") as mock_rec,
-            patch("milo_core.voice.engines.sd.wait"),
-        ):
-            mock_rec.return_value = np.zeros((16000, 1), dtype=np.float32)
+        pcm = np.zeros(16000, dtype=np.float32).tobytes()
+        with patch("milo_core.voice.engines.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout=pcm)
             stt = WhisperSTT()
             text = stt.listen()
-            mock_rec.assert_called_once_with(
-                16000, samplerate=16000, channels=1, dtype="float32"
-            )
+            mock_run.assert_called_once()
             assert text == "hello"
 
 
@@ -44,17 +40,17 @@ def test_coqui_tts_speak(monkeypatch) -> None:
             pass
 
     with patch("milo_core.voice.engines.threading.Thread", DummyThread):
-        with (
-            patch("milo_core.voice.engines.sd.play") as mock_play,
-            patch("milo_core.voice.engines.sd.wait"),
-        ):
+        with patch("milo_core.voice.engines.subprocess.Popen") as mock_popen:
+            proc = MagicMock()
+            proc.stdin = MagicMock()
+            mock_popen.return_value = proc
             tts_instance.synthesizer.output_sample_rate = 16000
             tts_instance.tts.return_value = np.array([0.0], dtype=np.float32)
             tts = CoquiTTS()
             tts.speak(["hi"])
             tts._queue.put(None)
             tts._run()
-            mock_play.assert_called_once()
+            mock_popen.assert_called_once()
 
     del sys.modules["TTS"]
     del sys.modules["TTS.api"]


### PR DESCRIPTION
## Summary
- update README instructions for ffmpeg based audio
- drop sounddevice dependency in pyproject
- refactor WhisperSTT and CoquiTTS to use ffmpeg/ffplay
- adjust unit tests for subprocess-based audio

## Testing
- `poetry run ruff format .`
- `poetry run ruff check .`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68423c1b8e30833081114e1829dc9ad5