### PR TITLE
[Test] expand coverage and add integration tests

### DIFF
--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+
+from milo_core.voice import conversation
+
+
+class DummyThread:
+    def __init__(self, target, daemon=False):
+        self.target = target
+
+    def start(self) -> None:  # pragma: no cover - thread logic mocked
+        pass
+
+    def join(self) -> None:  # pragma: no cover - thread logic mocked
+        pass
+
+
+def test_converse_handles_interruption(monkeypatch: pytest.MonkeyPatch) -> None:
+    stop_event = threading.Event()
+    monkeypatch.setattr(conversation.threading, "Event", lambda: stop_event)
+    monkeypatch.setattr(conversation.threading, "Thread", DummyThread)
+
+    session_memory = MagicMock()
+    monkeypatch.setattr(
+        conversation, "ShortTermMemory", MagicMock(return_value=session_memory)
+    )
+
+    model = MagicMock()
+    model.stream_response.return_value = iter(["He", "llo, ", "world"])
+
+    calls = ["hello", "raise"]
+
+    def listen_side_effect() -> str:
+        value = calls.pop(0)
+        if value == "raise":
+            raise KeyboardInterrupt
+        return value
+
+    stt = MagicMock()
+    stt.listen.side_effect = listen_side_effect
+
+    consumed: list[str] = []
+    tts = MagicMock()
+
+    def speak(tokens: list[str]) -> None:
+        for i, token in enumerate(tokens):
+            consumed.append(token)
+            if i == 0:
+                stop_event.set()
+                tts.stop()
+                break
+
+    tts.speak.side_effect = speak
+
+    memory_manager = MagicMock()
+
+    with pytest.raises(KeyboardInterrupt):
+        conversation.converse(model, stt, tts, memory_manager)
+
+    assert len(consumed) < 3
+    tts.stop.assert_called_once()
+    assistant_calls = [
+        c for c in session_memory.add_message.call_args_list if c.args[0] == "assistant"
+    ]
+    assert any("<interrupted_thought>" in c.args[1] for c in assistant_calls)

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from milo_core import commands
+from milo_core.main import main
+
+
+class DummySkill:
+    name = "test"
+
+    def execute(self) -> str:
+        return "executed"
+
+
+def test_end_to_end_skill_execution() -> None:
+    skill = DummySkill()
+    plugin_manager = MagicMock()
+    plugin_manager.get_skill_by_name.return_value = skill
+
+    stt = MagicMock()
+    stt.listen.return_value = "Milo, run the test skill"
+
+    model = MagicMock()
+    model.stream_response.return_value = iter(['{"type": "skill", "name": "test"}'])
+
+    tts = MagicMock()
+
+    memory_manager = MagicMock()
+
+    def fake_converse(model_arg, stt_arg, tts_arg, mem_arg):
+        stt_arg.listen()
+        tokens = list(model_arg.stream_response([]))
+        command_dict = eval(tokens[0])
+        result = commands.execute_command(command_dict, plugin_manager)
+        tts_arg.speak([result])
+
+    with (
+        patch("milo_core.main.GemmaLocalModel", return_value=model),
+        patch("milo_core.main.WhisperSTT", return_value=stt),
+        patch("milo_core.main.PiperTTS", return_value=tts),
+        patch("milo_core.main.PluginManager", return_value=plugin_manager),
+        patch("milo_core.memory_manager.MemoryManager", return_value=memory_manager),
+        patch("milo_core.main.converse", side_effect=fake_converse),
+        patch(
+            "milo_core.commands.execute_command", wraps=commands.execute_command
+        ) as exec_mock,
+    ):
+        main([])
+        exec_mock.assert_called_once_with(
+            {"type": "skill", "name": "test"}, plugin_manager
+        )
+
+    plugin_manager.get_skill_by_name.assert_called_with("test")
+    tts.speak.assert_called_with(["executed"])

--- a/tests/test_memory_manager.py
+++ b/tests/test_memory_manager.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 from milo_core.memory import Message
 from milo_core.memory_manager import MemoryManager
 
 
-def setup_manager() -> tuple[MemoryManager, MagicMock]:
+def setup_manager() -> tuple[MemoryManager, MagicMock, MagicMock]:
     mock_llm = MagicMock()
     mock_collection = MagicMock()
     mock_client = MagicMock()
@@ -17,19 +18,41 @@ def setup_manager() -> tuple[MemoryManager, MagicMock]:
         with patch("sentence_transformers.SentenceTransformer") as mock_model:
             mock_model.return_value.encode.return_value = [0.1, 0.2]
             manager = MemoryManager(mock_llm)
-    return manager, mock_collection
+    return manager, mock_collection, mock_llm
 
 
 def test_summarize_and_store_session_stores_when_useful() -> None:
-    manager, collection = setup_manager()
-    manager.llm.generate_response.side_effect = ["a summary", "YES"]
+    manager, collection, llm = setup_manager()
+    llm.generate_response.side_effect = ["a summary", "YES"]
     manager.summarize_and_store_session([Message(role="user", content="hi")])
     collection.add.assert_called_once()
 
 
+def test_summarize_and_store_session_skips_when_not_useful() -> None:
+    manager, collection, llm = setup_manager()
+    llm.generate_response.side_effect = ["a summary", "NO"]
+    manager.summarize_and_store_session([Message(role="user", content="hi")])
+    collection.add.assert_not_called()
+
+
 def test_retrieve_relevant_memories_queries_collection() -> None:
-    manager, collection = setup_manager()
+    manager, collection, _ = setup_manager()
     collection.query.return_value = {"documents": [["doc"]]}
     result = manager.retrieve_relevant_memories("query")
     assert result == ["doc"]
     collection.query.assert_called_once()
+
+
+def test_consolidate_memories() -> None:
+    manager, collection, llm = setup_manager()
+    old_ts = (datetime.now(timezone.utc) - timedelta(weeks=2)).isoformat()
+    collection.get.return_value = {
+        "documents": ["d1", "d2"],
+        "metadatas": [{"timestamp": old_ts}, {"timestamp": old_ts}],
+        "ids": ["id1", "id2"],
+    }
+    llm.generate_response.return_value = "digest"
+    manager.consolidate_memories()
+    assert "weekly digest" in llm.generate_response.call_args[0][0]
+    collection.add.assert_called_once()
+    collection.delete.assert_called_once_with(ids=["id1", "id2"])

--- a/tests/test_voice_engines.py
+++ b/tests/test_voice_engines.py
@@ -53,6 +53,7 @@ def test_whisper_stt_listen_with_vad() -> None:
         mock_model.transcribe.call_args[0][0],
         concatenated,
     )
+    mock_model.transcribe.assert_called_once()
 
 
 def test_piper_tts_speak(monkeypatch) -> None:
@@ -85,6 +86,8 @@ def test_piper_tts_speak(monkeypatch) -> None:
             tts._queue.put(None)
             tts._run()
             mock_popen.assert_called_once()
+            voice_instance.synthesize_stream_raw.assert_called_with("hi")
+            proc.stdin.write.assert_called_with(b"a")
 
     del sys.modules["piper"]
     del sys.modules["piper.voice"]


### PR DESCRIPTION
## Summary
- add interruption integration test for conversation loop
- enhance voice engine tests with additional assertions
- expand MemoryManager tests for summarization, retrieval, and consolidation
- add end-to-end skill execution test

## Testing
- `poetry run ruff check .`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842727c37788330be966883b7608264