### PR TITLE
[Refactor] Replace Piper TTS with Coqui TTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This project uses Poetry to manage its Python packages. Install them with a sing
 poetry install
 ```
 
-This will create a virtual environment and install all necessary libraries like faster-whisper, piper-tts, and llama-cpp-python.
+This will create a virtual environment and install all necessary libraries like faster-whisper, Coqui TTS, and llama-cpp-python.
 
 ### 3. Model Setup
 MILO requires a local language model and a text-to-speech (TTS) voice model to function.
@@ -83,11 +83,12 @@ Run the provided script to download the quantized Gemma model. This will save it
 
 **C. Download the TTS Voice Model**
 
-Next, download the pre-trained voice for the text-to-speech engine. The application expects this file to be in the root directory.
+Next, download a pre-trained voice for the text-to-speech engine. The application expects the model files in the project root.
 
 ```bash
-# Download the Piper TTS voice model
-wget '[https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_US/lessac/medium/en_US-lessac-medium.onnx?download=true](https://huggingface.co/rhasspy/piper-voices/resolve/main/en/en_US/lessac/medium/en_US-lessac-medium.onnx?download=true)' -O ./piper-voice.onnx
+# Example using a Coqui TTS model
+wget https://huggingface.co/coqui/XTTS-v2/resolve/main/model.pth?download=true -O ./coqui-voice.pth
+wget https://huggingface.co/coqui/XTTS-v2/resolve/main/config.json?download=true -O ./config.json
 ```
 
 ### 4. Running MILO

--- a/milo_core/main.py
+++ b/milo_core/main.py
@@ -4,7 +4,7 @@ from typing import List
 from milo_core.llm.gemma import GemmaLocalModel
 from milo_core.plugin_manager import PluginManager
 from milo_core.voice.conversation import converse
-from milo_core.voice.engines import WhisperSTT, PiperTTS
+from milo_core.voice.engines import WhisperSTT, CoquiTTS
 from milo_core.gui import run_gui
 
 
@@ -45,7 +45,7 @@ def run(args: argparse.Namespace) -> None:
         vad_threshold=args.vad_threshold,
         vad_silence_duration=args.vad_silence_duration,
     )
-    tts = PiperTTS("./piper-voice.onnx")
+    tts = CoquiTTS("./coqui-voice.pth", "./config.json")
 
     from milo_core.memory_manager import MemoryManager
 

--- a/milo_core/voice/__init__.py
+++ b/milo_core/voice/__init__.py
@@ -1,13 +1,13 @@
 """Voice utilities for MILO."""
 
 from .interface import SpeechToText, TextToSpeech
-from .engines import WhisperSTT, PiperTTS
+from .engines import WhisperSTT, CoquiTTS
 from .conversation import converse
 
 __all__ = [
     "SpeechToText",
     "TextToSpeech",
     "WhisperSTT",
-    "PiperTTS",
+    "CoquiTTS",
     "converse",
 ]

--- a/milo_core/voice/engines.py
+++ b/milo_core/voice/engines.py
@@ -93,16 +93,19 @@ class WhisperSTT(SpeechToText):
         return "".join(segment.text for segment in segments).strip()
 
 
-class PiperTTS(TextToSpeech):
-    """Text to speech engine using Piper and `ffplay` playback."""
+class CoquiTTS(TextToSpeech):
+    """Text to speech engine using Coqui TTS and ``ffplay`` playback."""
 
     def __init__(self, model_path: str, config_path: str | None = None) -> None:
         try:
-            from piper.voice import PiperVoice
+            from TTS.api import TTS
         except ModuleNotFoundError as exc:  # pragma: no cover - optional library
-            raise ImportError("piper-tts library is required for PiperTTS") from exc
+            raise ImportError("TTS library is required for CoquiTTS") from exc
 
-        self.voice = PiperVoice.load(model_path, config_path)
+        self.tts = TTS(
+            model_path=model_path, config_path=config_path, progress_bar=False
+        )
+        self.sample_rate = self.tts.synthesizer.output_sample_rate
         self._queue: queue.Queue[str] = queue.Queue()
         self._stop_event = threading.Event()
         self._process: subprocess.Popen | None = None
@@ -115,6 +118,8 @@ class PiperTTS(TextToSpeech):
             if text is None:  # type: ignore[comparison-overlap]
                 break
             if not self._stop_event.is_set():
+                audio = self.tts.tts(text)
+                pcm = (audio * 32767).astype("int16")
                 self._process = subprocess.Popen(
                     [
                         "ffplay",
@@ -125,7 +130,7 @@ class PiperTTS(TextToSpeech):
                         "-f",
                         "s16le",
                         "-ar",
-                        str(self.voice.config.sample_rate),
+                        str(self.sample_rate),
                         "-ac",
                         "1",
                         "-",
@@ -133,20 +138,15 @@ class PiperTTS(TextToSpeech):
                     stdin=subprocess.PIPE,
                 )
                 assert self._process.stdin is not None
-                for chunk in self.voice.synthesize_stream_raw(text):
-                    if self._stop_event.is_set():
-                        break
-                    self._process.stdin.write(chunk)
+                self._process.stdin.write(pcm.tobytes())
                 self._process.stdin.close()
                 self._process.wait()
             self._queue.task_done()
             self._stop_event.clear()
 
     def speak(self, tokens: Iterable[str]) -> None:
-        for token in tokens:
-            if self._stop_event.is_set():
-                break
-            self._queue.put(token)
+        text = "".join(tokens)
+        self._queue.put(text)
 
     def stop(self) -> None:
         self._stop_event.set()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "faster-whisper (>=1.1.1,<1.2.0)",
     "chromadb (>=1.0.12,<2.0.0)",
     "sentence-transformers (>=4.1.0,<5.0.0)",
-    "TTS (>=0.22.0,<0.23.0)", # Changed piper-tts to TTS (Coqui TTS)
+    "TTS (>=0.22.0,<0.23.0)", # Coqui TTS library
     "torch (>=2.7.1,<3.0.0)",
     "pyaudio (>=0.2.14,<0.3.0)",
     "webrtcvad-wheels (>=2.0.14,<3.0.0)"
@@ -39,7 +39,7 @@ llama-cpp-python = ">=0.2.71,<0.3.0"
 faster-whisper = ">=1.1.1,<1.2.0"
 chromadb = ">=1.0.12,<2.0.0"
 sentence-transformers = ">=4.1.0,<5.0.0"
-TTS = ">=0.22.0,<0.23.0" # Changed piper-tts to TTS (Coqui TTS)
+TTS = ">=0.22.0,<0.23.0" # Coqui TTS library
 torch = ">=2.7.1,<3.0.0"
 pyaudio = ">=0.2.14,<0.3.0"
 webrtcvad-wheels = ">=2.0.14,<3.0.0"

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -38,7 +38,7 @@ def test_end_to_end_skill_execution() -> None:
     with (
         patch("milo_core.main.GemmaLocalModel", return_value=model),
         patch("milo_core.main.WhisperSTT", return_value=stt),
-        patch("milo_core.main.PiperTTS", return_value=tts),
+        patch("milo_core.main.CoquiTTS", return_value=tts),
         patch("milo_core.main.PluginManager", return_value=plugin_manager),
         patch("milo_core.memory_manager.MemoryManager", return_value=memory_manager),
         patch("milo_core.main.converse", side_effect=fake_converse),

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -8,7 +8,7 @@ from milo_core.main import main
 @patch("milo_core.main.converse")
 @patch("milo_core.main.GemmaLocalModel")
 @patch("milo_core.main.WhisperSTT")
-@patch("milo_core.main.PiperTTS")
+@patch("milo_core.main.CoquiTTS")
 @patch("milo_core.main.PluginManager")
 @patch("milo_core.memory_manager.MemoryManager")
 def test_main_starts_conversation(


### PR DESCRIPTION
## Summary
- switch text-to-speech engine from Piper to Coqui
- update CLI and voice module exports
- adjust unit tests for the new engine
- refresh dependency comments and README instructions

## Testing
- `poetry run ruff format .`
- `poetry run ruff check .`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68437ea4a820833094c82462eeac3ed1