### PR TITLE
[Fix] Adjust Coqui TTS paths and loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Next, download a pre-trained voice for the text-to-speech engine. The applicatio
 
 ```bash
 # Example using a Coqui TTS model
-wget https://huggingface.co/coqui/XTTS-v2/resolve/main/model.pth?download=true -O ./coqui-voice.pth
+wget https://huggingface.co/coqui/XTTS-v2/resolve/main/model.pth?download=true -O ./model.pth
 wget https://huggingface.co/coqui/XTTS-v2/resolve/main/config.json?download=true -O ./config.json
 ```
 

--- a/milo_core/main.py
+++ b/milo_core/main.py
@@ -45,7 +45,7 @@ def run(args: argparse.Namespace) -> None:
         vad_threshold=args.vad_threshold,
         vad_silence_duration=args.vad_silence_duration,
     )
-    tts = CoquiTTS("./coqui-voice.pth", "./config.json")
+    tts = CoquiTTS("./model.pth", "./config.json")
 
     from milo_core.memory_manager import MemoryManager
 

--- a/milo_core/voice/engines.py
+++ b/milo_core/voice/engines.py
@@ -99,6 +99,15 @@ class CoquiTTS(TextToSpeech):
     def __init__(self, model_path: str, config_path: str | None = None) -> None:
         try:
             from TTS.api import TTS
+            from TTS.tts.configs.xtts_config import XttsConfig
+            from torch.serialization import add_safe_globals
+
+            # Allow loading checkpoints that reference the XTTS config class
+            # when using newer PyTorch versions with weights-only load.
+            try:  # pragma: no cover - torch may be missing in tests
+                add_safe_globals([XttsConfig])
+            except Exception:
+                pass
         except ModuleNotFoundError as exc:  # pragma: no cover - optional library
             raise ImportError("TTS library is required for CoquiTTS") from exc
 


### PR DESCRIPTION
## Summary
- set default TTS checkpoint to `model.pth`
- add PyTorch safe globals when loading XTTS
- clarify README on how to download TTS files

## Testing
- `poetry run ruff format .`
- `poetry run ruff check .`
- `poetry run pytest` *(fails: portaudio headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_6848beeebabc8330a90e024f4ed3962f