### PR TITLE
[Refactor] Improve chat GUI responsiveness

### DIFF
--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from milo_core.gui import app
+from milo_core.gui.app import run_gui
+
+
+class DummyGUI:
+    def __init__(self, on_end):
+        DummyGUI.instance = self
+        self.on_end = on_end
+        self.messages: list[tuple[str, str]] = []
+        self.counter = 0
+        self.root = MagicMock()
+        self.root.after = lambda delay, func, *a: func()
+
+    def set_send_callback(self, cb):
+        self.cb = cb
+
+    def add_message(self, author, msg):
+        self.messages.append((author, msg))
+        ident = f"{self.counter}"
+        self.counter += 1
+        return ident
+
+    def update_message(self, idx, author, msg):
+        pos = int(idx)
+        self.messages[pos] = (author, msg)
+
+    def mainloop(self):
+        self.cb("hello")
+        self.on_end()
+
+
+class DummyGoodbyeGUI(DummyGUI):
+    def mainloop(self):
+        self.cb("goodbye")
+        self.on_end()
+
+
+def test_run_gui_basic_flow(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(app, "MiloGUI", DummyGUI)
+    model = MagicMock()
+    model.stream_response.return_value = iter(["hi"])
+    memory = MagicMock()
+    memory.retrieve_relevant_memories.return_value = []
+    memory.consolidate_memories.return_value = None
+    run_gui(model, None, None, memory)
+    assert ("You", "hello") in DummyGUI.instance.messages
+    assert ("M.I.L.O", "hi") in DummyGUI.instance.messages
+    memory.consolidate_memories.assert_called_once()
+
+
+def test_run_gui_summarizes_on_goodbye(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(app, "MiloGUI", DummyGoodbyeGUI)
+    model = MagicMock()
+    model.stream_response.return_value = iter(["bye"])
+    memory = MagicMock()
+    memory.retrieve_relevant_memories.return_value = []
+    memory.consolidate_memories.return_value = None
+    run_gui(model, None, None, memory)
+    memory.summarize_and_store_session.assert_called_once()


### PR DESCRIPTION
## Summary
- refine chat window appearance and message coloring
- stream assistant responses on a background thread and update the GUI when done
- adapt GUI tests for the new async flow

## Testing
- `poetry run ruff format milo_core/gui/app.py tests/test_gui.py`
- `poetry run ruff check .`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687060a0e30c8330a8b8f5b48e3717e6