### PR TITLE
[Feature] Restore streaming GUI chat

### DIFF
--- a/milo_core/gui/app.py
+++ b/milo_core/gui/app.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Callable
+
 
 from tkinter import (
     Tk,
@@ -18,14 +20,40 @@ from milo_core.voice.interface import SpeechToText, TextToSpeech
 
 
 class MiloGUI:
-
+    """Basic Tkinter-based chat window."""
 
     def __init__(self, on_end: Callable[[], None]) -> None:
         self.root = Tk()
         self.root.title("MILO Chat")
         self.on_end = on_end
 
+        self.root.protocol("WM_DELETE_WINDOW", self._end)
 
+        frame = Frame(self.root)
+        frame.pack(fill="both", expand=True)
+
+        self.text_area = Text(frame, state="disabled", wrap="word")
+        self.text_area.pack(side="left", fill="both", expand=True)
+
+        scrollbar = Scrollbar(frame, command=self.text_area.yview)
+        scrollbar.pack(side="right", fill="y")
+        self.text_area.configure(yscrollcommand=scrollbar.set)
+
+        self.text_area.tag_configure("user", foreground="blue")
+        self.text_area.tag_configure("assistant", foreground="green")
+
+        entry_frame = Frame(self.root)
+        entry_frame.pack(fill="x")
+
+        self.entry = Entry(entry_frame)
+        self.entry.pack(side="left", fill="x", expand=True)
+        self.entry.bind("<Return>", self._handle_send)
+
+        send_btn = Button(entry_frame, text="Send", command=self._handle_send)
+        send_btn.pack(side="right")
+
+        self._send_callback: Callable[[str], None] | None = None
+        self._stream_tag: str | None = None
 
     def set_send_callback(self, callback: Callable[[str], None]) -> None:
         """Register the function to call when the user sends a message."""
@@ -42,8 +70,43 @@ class MiloGUI:
         self._send_callback(text)
 
     def add_message(self, author: str, message: str) -> None:
+        """Insert a completed message into the chat display."""
 
+        tag = "user" if author == "You" else "assistant"
+        self.text_area.configure(state="normal")
+        self.text_area.insert(END, f"{author}: {message}\n", tag)
         self.text_area.configure(state="disabled")
+        self.text_area.see(END)
+
+    def start_stream_message(self, author: str) -> None:
+        """Prepare to stream a new message from ``author``."""
+
+        tag = "user" if author == "You" else "assistant"
+        self._stream_tag = tag
+        self.text_area.configure(state="normal")
+        self.text_area.insert(END, f"{author}: ", tag)
+        self.text_area.configure(state="disabled")
+        self.text_area.see(END)
+
+    def append_stream_token(self, token: str) -> None:
+        """Append a streamed token to the current message."""
+
+        if self._stream_tag is None:
+            return
+        self.text_area.configure(state="normal")
+        self.text_area.insert(END, token, self._stream_tag)
+        self.text_area.configure(state="disabled")
+        self.text_area.see(END)
+
+    def end_stream_message(self) -> None:
+        """Finalize a streaming message."""
+
+        if self._stream_tag is None:
+            return
+        self.text_area.configure(state="normal")
+        self.text_area.insert(END, "\n")
+        self.text_area.configure(state="disabled")
+        self._stream_tag = None
         self.text_area.see(END)
 
     def _end(self) -> None:
@@ -68,7 +131,6 @@ def run_gui(
 
     gui = MiloGUI(lambda: None)
 
-
     def process_input(user_input: str) -> None:
         gui.add_message("You", user_input)
         relevant_memories = memory_manager.retrieve_relevant_memories(user_input)
@@ -79,6 +141,17 @@ def run_gui(
             )
         session_memory.add_message("user", user_input)
         history = session_memory.get_messages()
+        gui.start_stream_message("M.I.L.O")
+        tokens: list[str] = []
+        for token in model.stream_response(history):
+            tokens.append(token)
+            gui.append_stream_token(token)
+        gui.end_stream_message()
+        full_msg = "".join(tokens)
+        session_memory.add_message("assistant", full_msg)
+        if user_input.lower() == "goodbye":
+            memory_manager.summarize_and_store_session(session_memory.get_messages())
+            session_memory.clear()
 
     gui.set_send_callback(process_input)
     gui.mainloop()

--- a/milo_core/voice/engines.py
+++ b/milo_core/voice/engines.py
@@ -99,7 +99,7 @@ class PiperTTS(TextToSpeech):
                 buf = self._buffer_cls()
                 with wave.open(buf, "wb") as wf:
                     wf.setnchannels(1)
-                    wf.setsampwidth(2) # 2 bytes for 16-bit audio
+                    wf.setsampwidth(2)  # 2 bytes for 16-bit audio
                     wf.setframerate(self.sample_rate)
                     self.voice.synthesize(text, wf)
                 audio = (

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -7,11 +7,14 @@ import pytest
 from milo_core.gui import app
 from milo_core.gui.app import run_gui
 
+
 class DummyGUI:
     def __init__(self, on_end):
         DummyGUI.instance = self
         self.on_end = on_end
         self.messages: list[tuple[str, str]] = []
+        self._stream_author = ""
+        self._buffer = ""
 
     def set_send_callback(self, cb):
         self.cb = cb
@@ -19,6 +22,15 @@ class DummyGUI:
     def add_message(self, author, msg):
         self.messages.append((author, msg))
 
+    def start_stream_message(self, author):
+        self._stream_author = author
+        self._buffer = ""
+
+    def append_stream_token(self, token):
+        self._buffer += token
+
+    def end_stream_message(self):
+        self.messages.append((self._stream_author, self._buffer))
 
     def mainloop(self):
         self.cb("hello")


### PR DESCRIPTION
## Summary
- restore the GUI chat logic with streaming token display
- keep assistant context internal and only show the final reply
- update GUI unit tests for streaming support
- run formatters and linters

## Testing
- `poetry run ruff format .`
- `poetry run ruff check .`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68707187c1748330a6db819725a1af24