### PR TITLE
[Fix] Async GUI token streaming

### DIFF
--- a/milo_core/gui/app.py
+++ b/milo_core/gui/app.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from typing import Callable
 
+import queue
+import threading
+
 
 from tkinter import (
     Tk,
@@ -10,6 +13,7 @@ from tkinter import (
     Button,
     Scrollbar,
     Frame,
+    Label,
     END,
 )
 
@@ -32,28 +36,48 @@ class MiloGUI:
         frame = Frame(self.root)
         frame.pack(fill="both", expand=True)
 
-        self.text_area = Text(frame, state="disabled", wrap="word")
+        self.text_area = Text(
+            frame, state="disabled", wrap="word", font=("Helvetica", 12)
+        )
         self.text_area.pack(side="left", fill="both", expand=True)
 
         scrollbar = Scrollbar(frame, command=self.text_area.yview)
         scrollbar.pack(side="right", fill="y")
         self.text_area.configure(yscrollcommand=scrollbar.set)
 
-        self.text_area.tag_configure("user", foreground="blue")
-        self.text_area.tag_configure("assistant", foreground="green")
+        self.text_area.tag_configure("user", foreground="blue", spacing1=6, spacing3=6)
+        self.text_area.tag_configure(
+            "assistant", foreground="green", spacing1=6, spacing3=6
+        )
 
         entry_frame = Frame(self.root)
         entry_frame.pack(fill="x")
 
-        self.entry = Entry(entry_frame)
+        self.entry = Entry(entry_frame, font=("Helvetica", 12))
         self.entry.pack(side="left", fill="x", expand=True)
         self.entry.bind("<Return>", self._handle_send)
 
-        send_btn = Button(entry_frame, text="Send", command=self._handle_send)
-        send_btn.pack(side="right")
+        self.send_btn = Button(entry_frame, text="Send", command=self._handle_send)
+        self.send_btn.pack(side="right")
+
+        self.status = Label(self.root, text="")
+        self.status.pack(fill="x")
 
         self._send_callback: Callable[[str], None] | None = None
         self._stream_tag: str | None = None
+
+    def set_loading(self, loading: bool) -> None:
+        """Enable or disable user input and show loading status."""
+
+        state = "disabled" if loading else "normal"
+        self.entry.configure(state=state)
+        self.send_btn.configure(state=state)
+        self.status.configure(text="Thinking..." if loading else "")
+
+    def schedule(self, callback: Callable[[], None], delay: int = 50) -> None:
+        """Schedule ``callback`` to run after ``delay`` milliseconds."""
+
+        self.root.after(delay, callback)
 
     def set_send_callback(self, callback: Callable[[str], None]) -> None:
         """Register the function to call when the user sends a message."""
@@ -133,6 +157,8 @@ def run_gui(
 
     def process_input(user_input: str) -> None:
         gui.add_message("You", user_input)
+        gui.set_loading(True)
+
         relevant_memories = memory_manager.retrieve_relevant_memories(user_input)
         if relevant_memories:
             context_str = " ".join(relevant_memories)
@@ -141,17 +167,40 @@ def run_gui(
             )
         session_memory.add_message("user", user_input)
         history = session_memory.get_messages()
-        gui.start_stream_message("M.I.L.O")
+
+        token_queue: queue.Queue[str | None] = queue.Queue()
         tokens: list[str] = []
-        for token in model.stream_response(history):
-            tokens.append(token)
-            gui.append_stream_token(token)
-        gui.end_stream_message()
-        full_msg = "".join(tokens)
-        session_memory.add_message("assistant", full_msg)
-        if user_input.lower() == "goodbye":
-            memory_manager.summarize_and_store_session(session_memory.get_messages())
-            session_memory.clear()
+
+        def worker() -> None:
+            for token in model.stream_response(history):
+                tokens.append(token)
+                token_queue.put(token)
+            token_queue.put(None)
+
+        threading.Thread(target=worker, daemon=True).start()
+
+        gui.start_stream_message("M.I.L.O")
+
+        def poll_queue() -> None:
+            try:
+                while True:
+                    token = token_queue.get_nowait()
+                    if token is None:
+                        gui.end_stream_message()
+                        full_msg = "".join(tokens)
+                        session_memory.add_message("assistant", full_msg)
+                        if user_input.lower() == "goodbye":
+                            memory_manager.summarize_and_store_session(
+                                session_memory.get_messages()
+                            )
+                            session_memory.clear()
+                        gui.set_loading(False)
+                        return
+                    gui.append_stream_token(token)
+            except queue.Empty:
+                gui.schedule(poll_queue, 50)
+
+        poll_queue()
 
     gui.set_send_callback(process_input)
     gui.mainloop()

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -8,6 +8,14 @@ from milo_core.gui import app
 from milo_core.gui.app import run_gui
 
 
+class DummyThread:
+    def __init__(self, target, daemon=False):
+        self.target = target
+
+    def start(self) -> None:
+        self.target()
+
+
 class DummyGUI:
     def __init__(self, on_end):
         DummyGUI.instance = self
@@ -32,6 +40,12 @@ class DummyGUI:
     def end_stream_message(self):
         self.messages.append((self._stream_author, self._buffer))
 
+    def set_loading(self, loading):
+        pass
+
+    def schedule(self, cb, delay=0):
+        cb()
+
     def mainloop(self):
         self.cb("hello")
         self.on_end()
@@ -45,6 +59,7 @@ class DummyGoodbyeGUI(DummyGUI):
 
 def test_run_gui_basic_flow(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(app, "MiloGUI", DummyGUI)
+    monkeypatch.setattr(app, "threading", MagicMock(Thread=DummyThread))
     model = MagicMock()
     model.stream_response.return_value = iter(["hi"])
     memory = MagicMock()
@@ -58,6 +73,7 @@ def test_run_gui_basic_flow(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_run_gui_summarizes_on_goodbye(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(app, "MiloGUI", DummyGoodbyeGUI)
+    monkeypatch.setattr(app, "threading", MagicMock(Thread=DummyThread))
     model = MagicMock()
     model.stream_response.return_value = iter(["bye"])
     memory = MagicMock()


### PR DESCRIPTION
## Summary
- update MiloGUI with loading indicator and scheduling helper
- implement asynchronous token streaming in `run_gui`
- patch GUI tests for new async flow and helper methods
- apply minimal styling updates

## Testing
- `poetry run ruff format .`
- `poetry run ruff check .`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68708b366b688330b0d40c1fa5dd00dc